### PR TITLE
Improved url regex and validation.

### DIFF
--- a/server.js
+++ b/server.js
@@ -25,9 +25,9 @@ app.set("view engine", "handlebars");
 const Keyv = require("keyv");
 const links = new Keyv("sqlite://database.sqlite");
 // regex used to validate links
-var urlregex = new RegExp(
-  /[-a-zA-Z0-9@:%._\+~#=]{1,256}\.[a-zA-Z()]{1,6}\b([-a-zA-Z0-9()@:%_\+.~#?&//=]*)?/gi
-);
+// regex-weburl.js by Diego Perini0;
+var urlregex = new RegExp(/^(?:(?:(?:https?|ftp?|http):)?\/\/)(?:\S+(?::\S*)?@)?(?:(?!(?:10|127)(?:\.\d{1,3}){3})(?!(?:169\.254|192\.168)(?:\.\d{1,3}){2})(?!172\.(?:1[6-9]|2\d|3[0-1])(?:\.\d{1,3}){2})(?:[1-9]\d?|1\d\d|2[01]\d|22[0-3])(?:\.(?:1?\d{1,2}|2[0-4]\d|25[0-5])){2}(?:\.(?:[1-9]\d?|1\d\d|2[0-4]\d|25[0-4]))|(?:(?:[a-z0-9\u00a1-\uffff][a-z0-9\u00a1-\uffff_-]{0,62})?[a-z0-9\u00a1-\uffff]\.)+(?:[a-z\u00a1-\uffff]{2,}\.?))(?::\d{2,5})?(?:[/?#]\S*)?$/i);
+
 // generate random links if no vanity url is provided
 const words = require("friendly-words");
 
@@ -50,6 +50,28 @@ app.get("/", (request, response) => {
     layout: false,
   });
 });
+
+// validate that webpage is being served at url
+// uses axios and RegExp
+async function getValidUrl(url){
+  if (url.trim()=="") return false;
+  if (!url.match(urlRegEx)) return false;
+  try {
+      if (url.substring(0,6)!="https:" && url.substring(0,5)!="http:") {
+          let [test1, test2, validUrl] = ["https://" + url, "http://" + url, false];
+          let [res1, res2]  = [await axios.get(test1), await axios.get(test2)]
+          validUrl = (res1 != null ? test1 : (res2 != null ? test2 : false));
+      } else {
+          let res1 = await axios.get(url)
+          validUrl = (res1 != null ? url : false)
+      }
+  } catch (e) {
+    // some webpages terminate fetch requests early
+    validUrl = e.request.finished ? e.request._redirectable._currentUrl : false
+  }
+  return validUrl
+}
+
 // literally this simple, we check if vanity is taken. if not, we create a new
 // entry in db
 app.post("/shortenlink", async (request, response) => {
@@ -61,8 +83,9 @@ app.post("/shortenlink", async (request, response) => {
     // if the vanity is not taken
     if (!(await links.get(json.vanity))) {
       // if the link is valid
-      if (json.newlink.match(urlregex)) {
-        links.set(json.vanity, json.newlink);
+      let url = getValidUrl(json.newLink);
+      if (url != null && url != false) {
+        links.set(json.vanity, url);
         response.json({
           status:
             "Success! You can view your link at " +


### PR DESCRIPTION
Replaced current RegEx with Diego Perini's web-URL RegEx to validate URLs better
```js
var urlregex = new RegExp(/^(?:(?:(?:https?|ftp?|http):)?\/\/)(?:\S+(?::\S*)?@)?(?:(?!(?:10|127)(?:\.\d{1,3}){3})(?!(?:169\.254|192\.168)(?:\.\d{1,3}){2})(?!172\.(?:1[6-9]|2\d|3[0-1])(?:\.\d{1,3}){2})(?:[1-9]\d?|1\d\d|2[01]\d|22[0-3])(?:\.(?:1?\d{1,2}|2[0-4]\d|25[0-5])){2}(?:\.(?:[1-9]\d?|1\d\d|2[0-4]\d|25[0-4]))|(?:(?:[a-z0-9\u00a1-\uffff][a-z0-9\u00a1-\uffff_-]{0,62})?[a-z0-9\u00a1-\uffff]\.)+(?:[a-z\u00a1-\uffff]{2,}\.?))(?::\d{2,5})?(?:[/?#]\S*)?$/i);
```

Added method that uses [axios](https://www.npmjs.com/package/axios) to see if URL exists
```js
async function getValidUrl(url){
  if (url.trim()=="") return false;
  if (!url.match(urlRegEx)) return false;
  try {
      if (url.substring(0,6)!="https:" && url.substring(0,5)!="http:") {
          let [test1, test2, validUrl] = ["https://" + url, "http://" + url, false];
          let [res1, res2]  = [await axios.get(test1), await axios.get(test2)]
          validUrl = (res1 != null ? test1 : (res2 != null ? test2 : false));
      } else {
          let res1 = await axios.get(url)
          validUrl = (res1 != null ? url : false)
      }
  } catch (e) {
    // some webpages terminate fetch requests early
    validUrl = e.request.finished ? e.request._redirectable._currentUrl : false
  }
  return validUrl
}
```